### PR TITLE
Added "stats" option for Total Token and Cost Calculation per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A simple CLI chat tool designed for easy interaction with OpenAI's models.
 - Ability to generate images using OpenAI's image models.
     - Uses CLImage to display images directly in the terminal.
 - Supports both interactive and non-interactive chat modes.
+- Stats option that estimates how much you have spent per session.
 
 ## Demo
 
@@ -81,6 +82,10 @@ echo 'alias cha="path/to/cha"' >> $HOME/.bashrc
 ```
 
 You're now ready to go!
+
+## Important Notes
+
+- For the "--stats" option, the cost is estimated using hard-coded values gathered manually from OpenAI's [pricing](https://openai.com/pricing) website. If prices change, these values need to be manually updated. You can view or edit these prices in the `cha/cost.py` file in the `text_model_pricing()` function. If pricing has changed or a new model has been added, please raise an issue in this repo.
 
 ## Credits
 

--- a/cha/cost.py
+++ b/cha/cost.py
@@ -1,0 +1,44 @@
+import tiktoken
+
+
+def tokens_counter(model_name: str, string: str) -> int:
+    """Returns the number of tokens in a text string."""
+    encoding_name = tiktoken.encoding_for_model(model_name)
+    encoding = tiktoken.get_encoding(encoding_name.name)
+    num_tokens = len(encoding.encode(string))
+    return num_tokens
+
+
+def text_model_pricing(model):
+    """
+    UPDATED: April 16, 2024
+    SOURCE: https://openai.com/pricing
+    NOTES:
+        - The pricings are for every 1 Million tokens
+        - We only account for text based model
+        - We ignore image models, for now
+        - The cost is in dollars ($)
+    """
+    text_models = {
+        "gpt-4-turbo-2024-04-09": {"input": 10.00, "output": 30.00},
+        "gpt-4": {"input": 30.00, "output": 60.00},
+        "gpt-4-32k": {"input": 60.00, "output": 120.00},
+        "gpt-3.5-turbo-0125": {"input": 0.50, "output": 1.50},
+        "gpt-3.5-turbo-instruct": {"input": 1.50, "output": 2.00},
+        "gpt-4-0125-preview": {"input": 10.00, "output": 30.00},
+        "gpt-4-1106-preview": {"input": 10.00, "output": 30.00},
+        "gpt-4-vision-preview": {"input": 10.00, "output": 30.00},
+        "gpt-3.5-turbo-1106": {"input": 1.00, "output": 2.00},
+        "gpt-3.5-turbo-0613": {"input": 1.50, "output": 2.00},
+        "gpt-3.5-turbo-16k-0613": {"input": 3.00, "output": 4.00},
+        "gpt-3.5-turbo-0301": {"input": 1.50, "output": 2.00},
+    }
+
+    pricing = text_models.get(model)
+
+    if pricing != None:
+        pricing["official"] = True
+        return pricing
+
+    all_values = [info[key] for model, info in text_models.items() for key in info]
+    return {"official": False, "low": min(all_values), "high": max(all_values)}

--- a/cha/cost.py
+++ b/cha/cost.py
@@ -52,8 +52,13 @@ def text_model_pricing(model):
 
 
 def totals_costs_cal_and_print(selected_model, total_user_text, total_bot_text):
-    user_tokens = tokens_counter(selected_model, total_user_text)
-    bot_tokens = tokens_counter(selected_model, total_bot_text)
+    try:
+        user_tokens = tokens_counter(selected_model, total_user_text)
+        bot_tokens = tokens_counter(selected_model, total_bot_text)
+    except:
+        # NOTE: just used hard-coded model for token estimate
+        user_tokens = tokens_counter("gpt-4", total_user_text)
+        bot_tokens = tokens_counter("gpt-4", total_bot_text)
 
     user_cost = 0
     bot_cost = 0
@@ -62,6 +67,11 @@ def totals_costs_cal_and_print(selected_model, total_user_text, total_bot_text):
     if pricing["official"] == True:
         user_cost = (user_tokens / div) * pricing["input"]
         bot_cost = (bot_tokens / div) * pricing["output"]
+    else:
+        # NOTE: really estimate the pricing for models that are not listed/saved
+        est_avg_price = ((pricing["high"] + pricing["low"]) / 2) * 1.2
+        user_cost = (user_tokens / div) * est_avg_price
+        bot_cost = (bot_tokens / div) * est_avg_price
 
     stats = {
         "model_name": selected_model,

--- a/cha/main.py
+++ b/cha/main.py
@@ -310,6 +310,11 @@ def cli():
             "--string",
             help="None interactive mode, just feed a string into the model",
         )
+        parser.add_argument(
+            "--stats",
+            help="Enable printing of stats after the session",
+            action="store_true",
+        )
 
         args = parser.parse_args()
 
@@ -334,13 +339,12 @@ def cli():
 
             try:
                 selected_model = input("Which model do you want to use? ")
+                if selected_model not in [model[0] for model in openai_models]:
+                    print(colors.red("Invalid model selected. Exiting."))
+                    return
             except KeyboardInterrupt:
                 return
             print()
-
-        if selected_model not in [model[0] for model in openai_models]:
-            print(colors.red("Invalid model selected. Exiting."))
-            return
 
         if args.string and args.file:
             print(
@@ -362,8 +366,8 @@ def cli():
             chatbot(selected_model, title_print_value)
         except:
             pass
+
+        if args.stats:
+            print_stats(selected_model, CURRENT_CHAT_HISTORY)
     except:
         pass
-
-    # estimate total toke and cost for a session
-    print_stats(selected_model, CURRENT_CHAT_HISTORY)

--- a/cha/main.py
+++ b/cha/main.py
@@ -30,9 +30,7 @@ EXIT_STRING_KEY = "!e"
 ADVANCE_SEARCH_KEY = "!b"
 
 # important global variables
-CURRENT_CHAT_HISTORY = [
-    {"time": time.time(), "user": INITIAL_PROMPT, "bot": ""}
-]
+CURRENT_CHAT_HISTORY = [{"time": time.time(), "user": INITIAL_PROMPT, "bot": ""}]
 
 client = OpenAI(
     api_key=os.environ.get("OPENAI_API_KEY"),

--- a/cha/main.py
+++ b/cha/main.py
@@ -266,6 +266,30 @@ def basic_chat(filepath, model, justString=None):
         print(colors.red(f"Error during chat: {e}"))
 
 
+def print_stats(selected_model, the_chat=None):
+    try:
+        total_user_text = ""
+        total_bot_text = ""
+        for entry in the_chat:
+            total_user_text += str(entry["user"]) + " "
+            total_bot_text += str(entry["bot"]) + " "
+        stats = cost.totals_costs_cal_and_print(
+            selected_model, total_user_text, total_bot_text
+        )
+        print("\n\n")
+        print(colors.red(f"SESSION'S STATS:"))
+        print(colors.magenta(f"- LLM Model Name: {stats['model_name']}"))
+        print(colors.yellow(f"~ Total Input Tokens: {stats['input_tokens']}"))
+        print(colors.yellow(f"~ Total Output Tokens: {stats['output_tokens']}"))
+        print(colors.yellow(f"~ Total Tokens: {stats['total_tokens']}"))
+        print(colors.green(f"~ Total Input Cost: ${stats['input_cost']:.2f}"))
+        print(colors.green(f"~ Total Output Cost: ${stats['output_cost']:.2f}"))
+        print(colors.green(f"~ Total Image Gen Cost: $?"))
+        print(colors.green(f"~ Total Cost: ${stats['total_cost']:.2f}"))
+    except:
+        print(colors.red(f"Failed to calculate statistics from last session"))
+
+
 def cli():
     try:
         parser = argparse.ArgumentParser(description="Chat with an OpenAI GPT model.")
@@ -342,28 +366,4 @@ def cli():
         pass
 
     # estimate total toke and cost for a session
-
-    total_user_text = ""
-    total_bot_text = ""
-    for entry in CURRENT_CHAT_HISTORY:
-        total_user_text += str(entry["user"]) + " "
-        total_bot_text += str(entry["bot"]) + " "
-    user_tokens = cost.tokens_counter(selected_model, total_user_text)
-    bot_tokens = cost.tokens_counter(selected_model, total_bot_text)
-
-    user_cost = 0
-    bot_cost = 0
-    pricing = cost.text_model_pricing(selected_model)
-    if pricing["official"] == True:
-        user_cost = (user_tokens / 1_000_000) * pricing["input"]
-        bot_cost = (bot_tokens / 1_000_000) * pricing["output"]
-
-    print("\n\n")
-    print(f"Session Stats:")
-    print(f" - LLM Model Name: {selected_model}")
-    print(f" ~ Total Input Tokens: {user_tokens}")
-    print(f" ~ Total Output Tokens: {bot_tokens}")
-    print(f" ~ Total Total Tokens: {user_tokens + bot_tokens}")
-    print(f" ~ Total Input Cost: ${user_cost}")
-    print(f" ~ Total Output Cost: ${bot_cost}")
-    print(f" ~ Total Total Cost: ${user_cost + bot_cost}")
+    print_stats(selected_model, CURRENT_CHAT_HISTORY)

--- a/cha/main.py
+++ b/cha/main.py
@@ -277,15 +277,18 @@ def print_stats(selected_model, the_chat=None):
             selected_model, total_user_text, total_bot_text
         )
         print("\n\n")
-        print(colors.red(f"SESSION'S STATS:"))
+        print(colors.red(f"SESSION'S STATS (TEXT-BASED):"))
         print(colors.magenta(f"- LLM Model Name: {stats['model_name']}"))
-        print(colors.yellow(f"~ Total Input Tokens: {stats['input_tokens']}"))
-        print(colors.yellow(f"~ Total Output Tokens: {stats['output_tokens']}"))
-        print(colors.yellow(f"~ Total Tokens: {stats['total_tokens']}"))
-        print(colors.green(f"~ Total Input Cost: ${stats['input_cost']:.2f}"))
-        print(colors.green(f"~ Total Output Cost: ${stats['output_cost']:.2f}"))
-        print(colors.green(f"~ Total Image Gen Cost: $?"))
-        print(colors.green(f"~ Total Cost: ${stats['total_cost']:.2f}"))
+        print(
+            colors.yellow(
+                f"~ Total Input+Output Tokens: {stats['input_tokens']} + {stats['output_tokens']} = {stats['total_tokens']}"
+            )
+        )
+        print(
+            colors.green(
+                f"~ Total Input+Output Cost: ${stats['input_cost']:.2f} + ${stats['output_cost']:.2f} = ${stats['total_cost']}"
+            )
+        )
     except:
         print(colors.red(f"Failed to calculate statistics from last session"))
 

--- a/cha/main.py
+++ b/cha/main.py
@@ -282,7 +282,7 @@ def print_stats(selected_model, the_chat=None):
         stats = cost.totals_costs_cal_and_print(
             selected_model, total_user_text, total_bot_text
         )
-        print()
+        print("\n")
         print(colors.red(f"SESSION'S STATS (TEXT-BASED):"))
         print(colors.magenta(f"- LLM Model Name: {stats['model_name']}"))
         print(
@@ -372,6 +372,9 @@ def cli():
                 pass
 
         if args.stats:
-            print_stats(selected_model, CURRENT_CHAT_HISTORY)
+            try:
+                print_stats(selected_model, CURRENT_CHAT_HISTORY)
+            except:
+                print(colors.red("Failed to generate stats print"))
     except:
         pass


### PR DESCRIPTION
## About

Added the "stats" option that calculate/estimate the total number of tokens and cost you generated per session. By default, this option is disabled unless you enable it as an argument.

## Demo

```
> cha --stats -tp "false" -m "gpt-4"

User: Hello

Hi! How can I assist you today?

User: ^C

SESSION'S STATS (TEXT-BASED):
- LLM Model Name: gpt-4
~ Total Input+Output Tokens: 17 + 10 = 27
~ Total Input+Output Cost: $0.00 + $0.00 = $0.00111
```