### PR TITLE
Skip OpenAI model listing if model specified to reduce load time

### DIFF
--- a/cha.sh
+++ b/cha.sh
@@ -1,4 +1,3 @@
-
 #########################[CHA_CONFIGS]#########################
 
 # get OpenAI API key: https://platform.openai.com/api-keys
@@ -9,21 +8,20 @@ export BRAVE_API_KEY=""
 
 # cha's github repo: https://github.com/MehmetMHY/cha
 # run Cha in interactive mode (chat interface) without arguments or in non-interactive mode (processing one or multiple string arguments) if an argument is provided
-ca () {
-    # set a default OpenAI model
-    #   - model list: https://platform.openai.com/docs/models
-    DEFAULT_MODEL="gpt-4o"
+ca() {
+	# set a default OpenAI model
+	#   - model list: https://platform.openai.com/docs/models
+	DEFAULT_MODEL="gpt-4o"
 
-    if [[ "$1" == "-f" && -n "$2" ]]; then
-        cha -m $DEFAULT_MODEL -f "$2"
-    elif [ $# -eq 0 ]; then
-        cha --model $DEFAULT_MODEL
-    else
-        cha -m $DEFAULT_MODEL -s "$*"
-    fi
+	if [[ "$1" == "-f" && -n "$2" ]]; then
+		cha -m $DEFAULT_MODEL -f "$2"
+	elif [ $# -eq 0 ]; then
+		cha --model $DEFAULT_MODEL
+	else
+		cha -m $DEFAULT_MODEL -s "$*"
+	fi
 }
 
 alias chatgpt="ca"
 
 #########################[CHA_CONFIGS]#########################
-

--- a/cha/main.py
+++ b/cha/main.py
@@ -290,11 +290,10 @@ def cli():
         if str(args.titleprint).lower() == "false":
             title_print_value = False
 
-        openai_models = list_models()
+        selected_model = args.model
 
-        if args.model and any(model[0] == args.model for model in openai_models):
-            selected_model = args.model
-        else:
+        if selected_model == None:
+            openai_models = list_models()
             print(colors.yellow("Available OpenAI Models:"))
             max_length = max(len(model_id) for model_id, _ in openai_models)
             openai_models = sorted(openai_models, key=lambda x: x[1])


### PR DESCRIPTION
Modified Cha to not query OpenAI's list_model endpoint if a model is specified in the argument. This will reduce load time.

But, if the specified model is not a valid model, the Cha will still run but it will error out AFTER you enter a prompt. This is not great but I think it's worth it for the reduction in load time.